### PR TITLE
Add toolbar actions for zoom and snap-to-grid

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -264,26 +264,58 @@
             <mat-icon>{{isLeftPanelOpened?'arrow_left':'arrow_right'}}</mat-icon>
         </button>
 
-        <button mat-mini-fab
-            color="basic"
-            style="font-size: 1px; transform: none;position: absolute; right:56px; top:8px;"
-            matTooltip="Undo"
-            matTooltipPosition="below"
-            (click)="undo()"
-            [disabled]="!canUndo()"
-        >
-            <mat-icon>undo</mat-icon>
-        </button>
-        <button mat-mini-fab
-            color="basic"
-            style="font-size: 1px; transform: none;position: absolute; right:8px; top:8px;"
-            matTooltip="Redo"
-            matTooltipPosition="below"
-            (click)="redo()"
-            [disabled]="!canRedo()"
-        >
-            <mat-icon>redo</mat-icon>
-        </button>
+        <div class="scene-actions">
+            <button mat-flat-button
+                color="basic"
+                matTooltip="Undo"
+                matTooltipPosition="below"
+                (click)="undo()"
+                [disabled]="!canUndo()"
+            >
+                <mat-icon class="md-20">undo</mat-icon>
+            </button>
+            <button mat-flat-button
+                matTooltip="Redo"
+                matTooltipPosition="below"
+                (click)="redo()"
+                [disabled]="!canRedo()"
+            >
+                <mat-icon class="md-20">redo</mat-icon>
+            </button>
+            <button
+                mat-flat-button
+                (click)="zoomAuto()"
+                matTooltip="Reset view"
+                matTooltipPosition="below"
+                style="margin-left: 6px"
+            >
+                <mat-icon class="md-20">home</mat-icon> 
+            </button>
+            <button
+                mat-flat-button
+                (click)="canvas.zoomViewPort(0.9, {x: 0, y: 0})"
+                matTooltip="Zoom In"
+                matTooltipPosition="below"
+            >
+                <mat-icon class="md-20">zoom_in</mat-icon> 
+            </button>
+            <button
+                mat-flat-button
+                (click)="canvas.zoomViewPort(1.1, {x: 0, y: 0})"
+                matTooltip="Zoom Out"
+                matTooltipPosition="below"
+            >
+                <mat-icon class="md-20">zoom_out</mat-icon> 
+            </button>
+            <button
+                mat-flat-button
+                (click)="snapToGrid = !snapToGrid"
+                matTooltip="Snap to Grid"
+                matTooltipPosition="below"
+            >
+                <mat-icon class="md-20"> {{ snapToGrid ? 'grid_on' : 'grid_off' }}</mat-icon> 
+            </button>
+        </div>
 
         <svg xmlns="http://www.w3.org/2000/svg" app-canvas  #canvas [attr.viewBox]="viewPortX+' '+viewPortY+' '+viewPortWidth+' '+viewPortHeight" [ngClass]="{preview:preview}"
             [parsedPath]="parsedPath"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -93,13 +93,19 @@
                         matTooltipPosition="right"
                     >AUTO</button>
                 </div>
-                <div class="row">
-                    <div class="input-block" style="flex-grow: 1;"
+                <div class="row snap-option" [ngClass]="{'active': snapToGrid }">
+                    <mat-checkbox [(ngModel)]="snapToGrid" style="flex:1">Snap to Grid</mat-checkbox>
+                    <div class="input-block" style="flex:1"
                         matTooltip="Number of decimals to keep when a point is dragged"
                         matTooltipPosition="right"
                     >
-                        <label>Decimals on mouse drag</label>
-                        <input [(value)]="decimals" appFormatter formatterType="positive-integer" class="app-input">
+                        <label>Point Precision</label>
+                        <input
+                            class="app-input"
+                            appFormatter
+                            formatterType="integer"
+                            [(ngModel)]="decimalPrecision"
+                            [disabled]="snapToGrid">
                     </div>
                 </div>
                 <div class="row">

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -100,4 +100,24 @@ div.row.snap-option.active input {
         position: absolute;
         font-size: 1px;
     }
+    .material-icons.md-20 {
+        margin-top: -3px;
+        font-size: 20px;
+        justify-content: center;
+        align-items: center;
+        height: 20px;
+        width: 20px;
+      }
+
+      div.scene-actions {
+          position: absolute;
+          right: 15px;
+          top: 15px;
+      }
+
+      div.scene-actions button.mat-flat-button {
+        padding: 0 6px!important;
+        margin: 2px;
+      }
+
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -80,8 +80,15 @@ div.dragged {
     background-color:#094771;
 }
 
+div.row.snap-option.active input,
+div.row.snap-option.active label {
+    color: #737373;
+}
 
-
+div.row.snap-option.active input {
+    background: #333;
+    border-color: transparent;
+ }
 
 /* Drawings */
 .drawings {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -48,6 +48,7 @@ export class AppComponent implements AfterViewInit {
   preview = false;
   showTicks = false;
   minifyOutput = false;
+  snapToGrid = true;
   tickInterval = 5;
   roundValuesDecimals = 1;
 
@@ -56,7 +57,7 @@ export class AppComponent implements AfterViewInit {
   scaleY = 1;
   translateX = 0;
   translateY = 0;
-  decimals = 0;
+  decimalPrecision = 3;
 
   // Canvas Data:
   canvasWidth = 100;
@@ -108,6 +109,10 @@ export class AppComponent implements AfterViewInit {
       }
     }
   }
+
+  get decimals() {
+    return  this.snapToGrid ? 0 : this.decimalPrecision;
+ }
 
   ngAfterViewInit() {
     setTimeout(() => {

--- a/src/app/canvas/canvas.component.ts
+++ b/src/app/canvas/canvas.component.ts
@@ -154,8 +154,6 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
     }
   }
 
-
-
   eventToLocation(event: MouseEvent | TouchEvent, idx = 0): {x: number, y: number} {
     const rect = this.canvas.nativeElement.getBoundingClientRect();
     const touch = event instanceof MouseEvent ? event : event.touches[idx];
@@ -187,12 +185,18 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   mousewheel(event: {event: WheelEvent, deltaY: number}) {
-    const k = Math.pow(1.005, event.deltaY);
+    const scale = Math.pow(1.005, event.deltaY);
     const pt = this.eventToLocation(event.event);
-    const w = k * this.viewPortWidth;
-    const h = k * this.viewPortHeight;
-    const x = this.viewPortX + ((pt.x - this.viewPortX) - k * (pt.x - this.viewPortX));
-    const y = this.viewPortY + ((pt.y - this.viewPortY) - k * (pt.y - this.viewPortY));
+
+    this.zoomViewPort(scale, pt)
+  }
+
+  zoomViewPort(scale: number,  pt: {x: number, y: number}) {
+    const w = scale * this.viewPortWidth;
+    const h = scale * this.viewPortHeight;
+    const x = this.viewPortX + ((pt.x - this.viewPortX) - scale * (pt.x - this.viewPortX));
+    const y = this.viewPortY + ((pt.y - this.viewPortY) - scale * (pt.y - this.viewPortY));
+
     this.viewPort.emit({x, y, w, h});
   }
 


### PR DESCRIPTION
I worked on this back in June and then left it hanging since. Mainly decoupled some of the zoom logic so it could be reused for zoom out/in buttons and exposed some actions in a toolbar. When I went to rebase on your latest changes I noticed you added undo/redo buttons to a similar toolbar area and merged for consistency.

Not sure if it's a direction you'd want to go but figured I'd offer the pull request in case anything looked of interest. No worries if not

![zoom-snap-and-toolbar](https://user-images.githubusercontent.com/175113/99890408-b05fc800-2c13-11eb-8b34-5883a2816020.gif)
