### PR TITLE
Show "CapsLock On" text when CapsLock is on

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -338,6 +338,9 @@
         </button>
 
         <div class="scene-top-actions">
+          <label class="caps-lock"
+                [class.displayed]="isCapsLock"
+            >CapsLock On</label>
             <button mat-mini-fab
                 color="primary"
                 matTooltip="Undo"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -214,3 +214,14 @@ label.cursor-position {
     border-radius: 4px;
     pointer-events: none;
 }
+
+.caps-lock {
+  padding: 4px;
+  background-color: #383838;
+  color: white;
+  opacity: 0;
+  margin-right: 24px;
+  &.displayed {
+    opacity: 1;
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -78,6 +78,7 @@ export class AppComponent implements AfterViewInit {
   isLeftPanelOpened = true;
   isContextualMenuOpened = false;
   isEditingImages = false;
+  isCapsLock = false;
 
   // Utility functions:
   max = Math.max;
@@ -98,6 +99,7 @@ export class AppComponent implements AfterViewInit {
   }
 
   @HostListener('document:keydown', ['$event']) onKeyDown($event: KeyboardEvent) {
+    this.isCapsLock = $event.getModifierState('CapsLock');
     const tag = $event.target instanceof Element ? $event.target.tagName : null;
     if (tag !== 'INPUT' && tag !== 'TEXTAREA') {
       if ($event.shiftKey && ($event.metaKey || $event.ctrlKey) && $event.key.toLowerCase() === 'z') {


### PR DESCRIPTION

Will show "CapsLock On" text in the top right UI when caps lock is on

![image](https://github.com/Yqnn/svg-path-editor/assets/30274440/c43508df-8621-4291-8623-6b051d532da8)

There seems to be no way to detect this on load, but `$event.getModifierState('CapsLock')` seems to work when adding to `document:keydown`. When hitting any letter or the CapsLock itself, the correct state is added.

I tried to mimic the coding style of some other merged PRs and keep the aesthetic similar with the colors, padding, and right margin, but feel free to let me know if there's something you'd like updated.

Resolves https://github.com/Yqnn/svg-path-editor/issues/120