### PR TITLE
Automated grid

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -130,17 +130,6 @@
                 </div>
                 <div class="row">
                     <mat-checkbox [(ngModel)]="cfg.showTicks" style="flex:1">Show Ticks</mat-checkbox>
-                    <div class="input-block" style="flex:1"
-                        [ngClass]="{'disabled': !cfg.showTicks }"
-                    >
-                        <label>Interval</label>
-                        <input
-                            class="app-input"
-                            appFormatter
-                            formatterType="positive-integer"
-                            [(numberValue)]="cfg.tickInterval"
-                            [disabled]="!cfg.showTicks">
-                    </div>
                 </div>
                 <div class="row">
                     <mat-checkbox [(ngModel)]="cfg.filled" style="flex:1">Fill</mat-checkbox>

--- a/src/app/canvas/canvas.component.html
+++ b/src/app/canvas/canvas.component.html
@@ -17,7 +17,7 @@
     />
     <svg:line *ngFor="let x of xGrid; trackBy:trackByIndex"
         class="grid"
-        [ngClass]="{'tick': showTicks && x % tickInterval === 0 }"
+        [ngClass]="{'tick': showTicks && x % gridLabelStep === 0 }"
         [attr.x1]="x"
         [attr.y1]="viewPortY"
         [attr.x2]="x"
@@ -27,17 +27,17 @@
 
     <ng-container *ngIf="!preview && showTicks">
         <ng-container *ngFor="let y of yGrid; trackBy:trackByIndex">
-            <svg:text class="tick" *ngIf="y % tickInterval ===  0" [attr.x]="-4*strokeWidth" [attr.y]="y - 4*strokeWidth" [ngStyle]="{'font-size': strokeWidth*14+'px'}" >{{ y }}</text>
+            <svg:text class="tick" *ngIf="y % gridLabelStep ===  0" [attr.x]="-4*strokeWidth" [attr.y]="y - 4*strokeWidth" [ngStyle]="{'font-size': strokeWidth*14+'px'}" >{{ y }}</text>
         </ng-container>
 
         <ng-container *ngFor="let x of xGrid; trackBy:trackByIndex">
-            <svg:text class="tick" *ngIf="x !== 0 && x % tickInterval === 0" [attr.x]="x - 4*strokeWidth" [attr.y]="-4*strokeWidth" [ngStyle]="{'font-size': strokeWidth*14+'px'}">{{ x }}</text>
+            <svg:text class="tick" *ngIf="x !== 0 && x % gridLabelStep === 0" [attr.x]="x - 4*strokeWidth" [attr.y]="-4*strokeWidth" [ngStyle]="{'font-size': strokeWidth*14+'px'}">{{ x }}</text>
         </ng-container>
     </ng-container>
 
     <svg:line *ngFor="let y of yGrid; trackBy:trackByIndex"
         class="grid"
-        [ngClass]="{'tick': showTicks && y % tickInterval === 0 }"
+        [ngClass]="{'tick': showTicks && y % gridLabelStep === 0 }"
         [attr.x1]="viewPortX"
         [attr.y1]="y"
         [attr.x2]="viewPortX + viewPortWidth"

--- a/src/app/canvas/canvas.component.ts
+++ b/src/app/canvas/canvas.component.ts
@@ -84,6 +84,7 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
   draggedImageType = 0;
   xGrid: number[] = [];
   yGrid: number[] = [];
+  gridLabelStep = 1;
 
   // Utility functions
   min = Math.min;
@@ -170,13 +171,26 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   refreshGrid() {
-    if (5 * this.viewPortWidth <= this.canvasWidth) {
-      this.xGrid = Array(Math.ceil(this.viewPortWidth) + 1).fill(null).map((_, i) => Math.floor(this.viewPortX) + i);
-      this.yGrid = Array(Math.ceil(this.viewPortHeight) + 1).fill(null).map((_, i) => Math.floor(this.viewPortY) + i);
-    } else {
-      this.xGrid = [];
-      this.yGrid = [];
-    }
+    const niceStep = (minPx: number): number => {
+      const raw = this.canvasWidth > 0 ? this.viewPortWidth / (this.canvasWidth / minPx) : 1;
+      const e = Math.floor(Math.log10(Math.max(raw, 1e-10)));
+      const p = Math.pow(10, e);
+      if (raw <= p)     return p;
+      if (raw <= 2 * p) return 2 * p;
+      if (raw <= 5 * p) return 5 * p;
+      return 10 * p;
+    };
+
+    const step = niceStep(8);       // fine grid lines (~4-5× denser than labels)
+    this.gridLabelStep = niceStep(40); // tick labels
+
+    const xStart = Math.floor(this.viewPortX / step) * step;
+    const xCount = Math.ceil(this.viewPortWidth / step) + 2;
+    this.xGrid = Array.from({length: xCount}, (_, i) => xStart + i * step);
+
+    const yStart = Math.floor(this.viewPortY / step) * step;
+    const yCount = Math.ceil(this.viewPortHeight / step) + 2;
+    this.yGrid = Array.from({length: yCount}, (_, i) => yStart + i * step);
   }
 
   eventToLocation(event: MouseEvent | TouchEvent, idx = 0): {x: number, y: number} {


### PR DESCRIPTION
In the current master, the ticks' interval is manually set in the configuration pane and grid and ticks hide after some zooming out. This is not very practical if one wants larger paths, or simply use a 1000 something scale for their drawings.

This PR attempts to automate grid and ticks density to have a nice display for any zoom level. And therefore removes the manual tick interval configuration.

I understand this might not suit all users, it's up to you.