### PR TITLE
Improve dynamic grid

### DIFF
--- a/src/app/canvas/canvas.component.css
+++ b/src/app/canvas/canvas.component.css
@@ -1,70 +1,90 @@
 :host {
-    background-color:#1e1e1e;
+    background-color: #1e1e1e;
     user-select: none;
 }
+
 path {
-    stroke:white;
-    fill:none;
+    stroke: white;
+    fill: none;
 }
+
 path.filled {
-    fill:rgba(255,255,255,0.25);
+    fill: rgba(255, 255, 255, 0.25);
 }
+
 path.hovered {
     stroke: red;
     fill: none;
 }
+
 path.dragged {
     stroke: rgb(0, 174, 255);
     fill: none;
 }
-line.grid {
-    stroke:#353536;
+
+rect.grid {
+    fill: #353536;
+    stroke: none;
 }
 
-line.grid.tick {
-    stroke: #454545;
+rect.grid.tick {
+    fill: #454545;
+    stroke: none;
 }
 
 line.control {
-    stroke:gray;
+    stroke: gray;
 }
+
 line.hovered {
-    stroke:red;
+    stroke: red;
 }
+
 circle {
     cursor: pointer;
     stroke: transparent;
 }
+
 circle.control {
-    fill:gray;
+    fill: gray;
 }
+
 circle.target {
-    fill:white;
+    fill: white;
 }
+
 circle.hovered {
-    fill:red;
+    fill: red;
 }
+
 circle.dragged {
-    fill:rgb(0, 174, 255);
+    fill: rgb(0, 174, 255);
 }
+
 :host.preview {
-    background-color:white;
+    background-color: white;
 }
+
 :host.preview path {
-    stroke:black;
+    stroke: black;
 }
+
 :host.preview path.filled {
-    fill:black;
-    stroke:none;
+    fill: black;
+    stroke: none;
 }
+
 :host.preview path.hovered {
     stroke: red;
     fill: none;
 }
+
 :host.preview circle,
-:host.preview line {
+:host.preview line,
+:host.preview rect {
     display: none;
 }
+
 text.tick {
     fill: #595959;
     text-anchor: end;
@@ -80,35 +100,44 @@ text.tick {
 image {
     pointer-events: none;
 }
+
 rect.image-control {
-    fill: rgba(0,0,0,0);
+    fill: rgba(0, 0, 0, 0);
     stroke: none;
 }
+
 line.image-control {
-    stroke:gray;
+    stroke: gray;
 }
+
 circle.image-control {
-    fill:gray;
+    fill: gray;
 }
+
 .focused-image line.image-control {
-    stroke:rgb(0, 174, 255);
+    stroke: rgb(0, 174, 255);
 }
+
 .focused-image circle.image-control {
-    fill:rgb(0, 174, 255);
+    fill: rgb(0, 174, 255);
 }
 
 .image-control.horizontal {
     cursor: ns-resize;
 }
+
 .image-control.vertical {
     cursor: ew-resize;
 }
+
 .image-control.down {
     cursor: nwse-resize;
 }
+
 .image-control.up {
     cursor: nesw-resize;
 }
+
 .image-control.move {
     cursor: move;
 }

--- a/src/app/canvas/canvas.component.html
+++ b/src/app/canvas/canvas.component.html
@@ -1,47 +1,59 @@
 <ng-container *ngIf="strokeWidth" >
-    <svg:line
+    <svg:rect  *ngFor="let x of xGrid; trackBy:trackByIndex"
         class="grid"
-        [attr.x1]="viewPortX"
-        [attr.y1]="0"
-        [attr.x2]="viewPortX + viewPortWidth"
-        [attr.y2]="0"
-        [attr.stroke-width]="4*strokeWidth"
+        [attr.x]="x - 0.5*strokeWidth"
+        [attr.y]="viewPortY"
+        [attr.width]="strokeWidth"
+        [attr.height]="viewPortHeight"
     />
-    <svg:line
+    <svg:rect  *ngFor="let y of yGrid; trackBy:trackByIndex"
         class="grid"
-        [attr.x1]="0"
-        [attr.y1]="viewPortY"
-        [attr.x2]="0"
-        [attr.y2]="viewPortY + viewPortHeight"
-        [attr.stroke-width]="4*strokeWidth"
-    />
-    <svg:line *ngFor="let x of xGrid; trackBy:trackByIndex"
-        class="grid"
-        [ngClass]="{'tick': showTicks && isEvenTick(x) }"
-        [attr.x1]="x"
-        [attr.y1]="viewPortY"
-        [attr.x2]="x"
-        [attr.y2]="viewPortY + viewPortHeight"
-        [attr.stroke-width]="strokeWidth"
+        [attr.x]="viewPortX"
+        [attr.y]="y - 0.5*strokeWidth"
+        [attr.width]="viewPortWidth"
+        [attr.height]="strokeWidth"
     />
 
-    <svg:line *ngFor="let y of yGrid; trackBy:trackByIndex"
-        class="grid"
-        [ngClass]="{'tick': showTicks && isEvenTick(y) }"
-        [attr.x1]="viewPortX"
-        [attr.y1]="y"
-        [attr.x2]="viewPortX + viewPortWidth"
-        [attr.y2]="y"
+    <svg:rect *ngFor="let x of xGridSecondary; trackBy:trackByIndex"
+        class="grid tick"
+        [attr.x]="x - 0.5*strokeWidth"
+        [attr.y]="viewPortY"
+        [attr.width]="strokeWidth"
+        [attr.height]="viewPortHeight"
         [attr.stroke-width]="strokeWidth"
+    />
+    <svg:rect *ngFor="let y of yGridSecondary; trackBy:trackByIndex"
+        class="grid tick"
+        [attr.x]="viewPortX"
+        [attr.y]="y - 0.5*strokeWidth"
+        [attr.width]="viewPortWidth"
+        [attr.height]="strokeWidth"
+        [attr.stroke-width]="strokeWidth"
+    />
+    <svg:rect
+        class="grid"
+        [ngClass]="{'tick': showTicks }"
+        [attr.x]="viewPortX "
+        [attr.y]="-2*strokeWidth"
+        [attr.width]="viewPortWidth"
+        [attr.height]="4*strokeWidth"
+    />
+    <svg:rect
+        class="grid"
+        [ngClass]="{'tick': showTicks }"
+        [attr.x]="-2*strokeWidth"
+        [attr.y]="viewPortY"
+        [attr.width]="4*strokeWidth"
+        [attr.height]="viewPortHeight"
     />
 
     <ng-container *ngIf="!preview && showTicks">
-        <ng-container *ngFor="let y of yGrid; trackBy:trackByIndex">
-            <svg:text class="tick" *ngIf="isEvenTick(y)" [attr.x]="-4*strokeWidth" [attr.y]="y - 4*strokeWidth" [ngStyle]="{'font-size': strokeWidth*14+'px'}" >{{ y }}</text>
+        <ng-container *ngFor="let y of yGridSecondary; trackBy:trackByIndex">
+            <svg:text class="tick" [attr.x]="-4*strokeWidth" [attr.y]="y - 4*strokeWidth" [ngStyle]="{'font-size': strokeWidth*14+'px'}" >{{ y }}</text>
         </ng-container>
 
-        <ng-container *ngFor="let x of xGrid; trackBy:trackByIndex">
-            <svg:text class="tick" *ngIf="x !== 0 && isEvenTick(x)" [attr.x]="x - 4*strokeWidth" [attr.y]="-4*strokeWidth" [ngStyle]="{'font-size': strokeWidth*14+'px'}">{{ x }}</text>
+        <ng-container *ngFor="let x of xGridSecondary; trackBy:trackByIndex">
+            <svg:text class="tick" *ngIf="x !== 0" [attr.x]="x - 4*strokeWidth" [attr.y]="-4*strokeWidth" [ngStyle]="{'font-size': strokeWidth*14+'px'}">{{ x }}</text>
         </ng-container>
     </ng-container>
 

--- a/src/app/canvas/canvas.component.ts
+++ b/src/app/canvas/canvas.component.ts
@@ -81,6 +81,8 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
   draggedImageType = 0;
   xGrid: number[] = [];
   yGrid: number[] = [];
+  xGridSecondary: number[] = [];
+  yGridSecondary: number[] = [];
   gridLabelStep = 1;
 
   // Utility functions
@@ -89,7 +91,7 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
   trackByIndex = (idx: number, _: unknown) => idx;
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['viewPortX'] || changes['viewPortY'] || changes['viewPortWidth'] || changes['viewPortHeight']) {
+    if (changes['viewPortX'] || changes['viewPortY'] || changes['viewPortWidth'] || changes['viewPortHeight'] || changes['showTicks']) {
       this.refreshGrid();
     }
     if (changes['draggedPoint'] && changes['draggedPoint'].currentValue) {
@@ -173,30 +175,33 @@ export class CanvasComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   refreshGrid() {
-    const niceStep = (minPx: number): number => {
-      const raw = this.canvasWidth > 0 ? this.viewPortWidth / (this.canvasWidth / minPx) : 1;
-      const e = Math.floor(Math.log10(Math.max(raw, 1e-10)));
-      const p = Math.pow(10, e);
-      if (raw <= p){
-        return p;
-      } else if (raw <= 2 * p) {
-        return 2 * p;
-      } else if (raw <= 5 * p) {
-        return 5 * p;
-      }
-      return 10 * p;
-    };
+    const minPx = 10;
+    const raw = this.canvasWidth > 0 ? minPx * this.viewPortWidth / this.canvasWidth  : 1;
+    const e = Math.ceil(Math.log10(Math.max(raw, 1e-10)));
 
-    const step = niceStep(8);       // fine grid lines (~4-5× denser than labels)
-    this.gridLabelStep = niceStep(40); // tick labels
-
+    let step = Math.pow(10, Math.max(e, -4));
+    if(!this.showTicks) {
+      step = Math.max(step, 1);
+    }
     const xStart = Math.floor(this.viewPortX / step) * step;
     const xCount = Math.ceil(this.viewPortWidth / step) + 2;
     this.xGrid = Array.from({length: xCount}, (_, i) => this.round(xStart + i * step));
-
     const yStart = Math.floor(this.viewPortY / step) * step;
     const yCount = Math.ceil(this.viewPortHeight / step) + 2;
     this.yGrid = Array.from({length: yCount}, (_, i) => this.round(yStart + i * step));
+
+    if(this.showTicks) {
+      const secStep = (step < 1 ? 10 : 5 )*step;
+      const xSecStart = Math.floor(this.viewPortX / secStep) * secStep;
+      const xSecCount = Math.ceil(this.viewPortWidth / secStep) + 2;
+      this.xGridSecondary = Array.from({length: xSecCount}, (_, i) => this.round(xSecStart + i * secStep));
+      const ySecStart = Math.floor(this.viewPortY / secStep) * secStep;
+      const ySecCount = Math.ceil(this.viewPortHeight / secStep) + 2;
+      this.yGridSecondary = Array.from({length: ySecCount}, (_, i) => this.round(ySecStart + i * secStep));
+    } else {
+      this.xGridSecondary = [];
+      this.yGridSecondary = [];
+    }
   }
 
   eventToLocation(event: MouseEvent | TouchEvent, idx = 0): {x: number, y: number} {


### PR DESCRIPTION
Improve the dynamic grid behavior:
- When show-ticks is disabled:
    - use powers of 10 with min=1
- When show-ticks is enabled:
    - main ticks: use negative powers of 10 or 5 * positive power of 10.
    - secondary ticks: use powers of 10 with min=-3
- Use squares instead of lines to improve max zoom in Safari